### PR TITLE
Change SerializeModule to have typed description

### DIFF
--- a/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
@@ -5,6 +5,7 @@ namespace UGF.Module.Serialize.Runtime
 {
     public interface ISerializeModule : IApplicationModuleDescribed
     {
+        new ISerializeModuleDescription Description { get; }
         ISerializerProvider Provider { get; }
 
         ISerializer<byte[]> GetDefaultBytesSerializer();

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
@@ -6,11 +6,13 @@ using UGF.Serialize.Runtime;
 
 namespace UGF.Module.Serialize.Runtime
 {
-    public class SerializeModule : ApplicationModuleDescribed<ISerializeModuleDescription>, ISerializeModule
+    public class SerializeModule : ApplicationModuleDescribed<SerializeModuleDescription>, ISerializeModule
     {
         public ISerializerProvider Provider { get; }
 
-        public SerializeModule(IApplication application, ISerializeModuleDescription description, ISerializerProvider provider = null) : base(application, description)
+        ISerializeModuleDescription ISerializeModule.Description { get { return Description; } }
+
+        public SerializeModule(IApplication application, SerializeModuleDescription description, ISerializerProvider provider = null) : base(application, description)
         {
             Provider = provider ?? new SerializerProvider();
         }

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace UGF.Module.Serialize.Runtime
 {
     [CreateAssetMenu(menuName = "UGF/Serialize/Serialize Module", order = 2000)]
-    public class SerializeModuleAsset : ApplicationModuleDescribedAsset<ISerializeModule, ISerializeModuleDescription>
+    public class SerializeModuleAsset : ApplicationModuleDescribedAsset<ISerializeModule, SerializeModuleDescription>
     {
         [AssetGuid(typeof(SerializerAsset))]
         [SerializeField] private string m_defaultBytes;
@@ -21,7 +21,7 @@ namespace UGF.Module.Serialize.Runtime
         public string DefaultText { get { return m_defaultText; } set { m_defaultText = value; } }
         public List<AssetReference<SerializerAsset>> Serializers { get { return m_serializers; } }
 
-        protected override ISerializeModuleDescription OnGetDescription(IApplication application)
+        protected override SerializeModuleDescription OnGetDescription(IApplication application)
         {
             var description = new SerializeModuleDescription
             {
@@ -42,7 +42,7 @@ namespace UGF.Module.Serialize.Runtime
             return description;
         }
 
-        protected override ISerializeModule OnBuild(IApplication application, ISerializeModuleDescription description)
+        protected override ISerializeModule OnBuild(IApplication application, SerializeModuleDescription description)
         {
             return new SerializeModule(application, description);
         }


### PR DESCRIPTION
- Change `SerializeModule` to receive `SerializeModuleDescription` type of description instead of `ISerializeModuleDescription`.
- Change `SerializeModuleAsset` to build `SerializeModuleDescription` type of description instead of `ISerializeModuleDescription`.
- Add `ISerializeModule.Description` property with return type of `ISerializeModuleDescription `.