### PR TITLE
Update to support latest application package

### DIFF
--- a/Assets/UGF.Module.Serialize.Runtime.Tests/UGF.Module.Serialize.Runtime.Tests.asmdef
+++ b/Assets/UGF.Module.Serialize.Runtime.Tests/UGF.Module.Serialize.Runtime.Tests.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:1b64e8c1b5d6a0544b302c8a8d107ca9",
         "GUID:a4312e46e9f64bb4aa011ac96ffd2a61",
-        "GUID:d067af32d09350a4bb33960432735e4d"
+        "GUID:d067af32d09350a4bb33960432735e4d",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:3ad3a680cb737c6428dc532d551e7bb7"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Module.Serialize/Editor/SerializeModuleAssetEditor.cs
+++ b/Packages/UGF.Module.Serialize/Editor/SerializeModuleAssetEditor.cs
@@ -1,12 +1,12 @@
-﻿using UGF.Application.Editor;
-using UGF.EditorTools.Editor.IMGUI.AssetReferences;
+﻿using UGF.EditorTools.Editor.IMGUI.AssetReferences;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UGF.Module.Serialize.Runtime;
 using UnityEditor;
 
 namespace UGF.Module.Serialize.Editor
 {
     [CustomEditor(typeof(SerializeModuleAsset), true)]
-    internal class SerializeModuleAssetEditor : ApplicationModuleAssetEditor
+    internal class SerializeModuleAssetEditor : UnityEditor.Editor
     {
         private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyDefaultBytes;
@@ -30,21 +30,18 @@ namespace UGF.Module.Serialize.Editor
 
         public override void OnInspectorGUI()
         {
-            serializedObject.UpdateIfRequiredOrScript();
-
-            using (new EditorGUI.DisabledScope(true))
+            using (new SerializedObjectUpdateScope(serializedObject))
             {
-                EditorGUILayout.PropertyField(m_propertyScript);
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    EditorGUILayout.PropertyField(m_propertyScript);
+                }
+
+                EditorGUILayout.PropertyField(m_propertyDefaultBytes);
+                EditorGUILayout.PropertyField(m_propertyDefaultText);
+
+                m_list.DrawGUILayout();
             }
-
-            EditorGUILayout.PropertyField(m_propertyDefaultBytes);
-            EditorGUILayout.PropertyField(m_propertyDefaultText);
-
-            m_list.DrawGUILayout();
-
-            serializedObject.ApplyModifiedProperties();
-
-            DrawModuleRegisterTypeInfo();
         }
     }
 }

--- a/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
@@ -3,7 +3,7 @@ using UGF.Serialize.Runtime;
 
 namespace UGF.Module.Serialize.Runtime
 {
-    public interface ISerializeModule : IApplicationModuleDescribed
+    public interface ISerializeModule : IApplicationModule
     {
         new ISerializeModuleDescription Description { get; }
         ISerializerProvider Provider { get; }

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
@@ -6,15 +6,19 @@ using UGF.Serialize.Runtime;
 
 namespace UGF.Module.Serialize.Runtime
 {
-    public class SerializeModule : ApplicationModuleDescribed<SerializeModuleDescription>, ISerializeModule
+    public class SerializeModule : ApplicationModule<SerializeModuleDescription>, ISerializeModule
     {
         public ISerializerProvider Provider { get; }
 
         ISerializeModuleDescription ISerializeModule.Description { get { return Description; } }
 
-        public SerializeModule(IApplication application, SerializeModuleDescription description, ISerializerProvider provider = null) : base(application, description)
+        public SerializeModule(SerializeModuleDescription description, IApplication application) : this(description, application, new SerializerProvider())
         {
-            Provider = provider ?? new SerializerProvider();
+        }
+
+        public SerializeModule(SerializeModuleDescription description, IApplication application, ISerializerProvider provider) : base(description, application)
+        {
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
         }
 
         protected override void OnInitialize()

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace UGF.Module.Serialize.Runtime
 {
-    [CreateAssetMenu(menuName = "UGF/Serialize/Serialize Module", order = 2000)]
+    [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serialize Module", order = 2000)]
     public class SerializeModuleAsset : ApplicationModuleAsset<ISerializeModule, SerializeModuleDescription>
     {
         [AssetGuid(typeof(SerializerAsset))]

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModuleAsset.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace UGF.Module.Serialize.Runtime
 {
     [CreateAssetMenu(menuName = "UGF/Serialize/Serialize Module", order = 2000)]
-    public class SerializeModuleAsset : ApplicationModuleDescribedAsset<ISerializeModule, SerializeModuleDescription>
+    public class SerializeModuleAsset : ApplicationModuleAsset<ISerializeModule, SerializeModuleDescription>
     {
         [AssetGuid(typeof(SerializerAsset))]
         [SerializeField] private string m_defaultBytes;
@@ -21,9 +21,9 @@ namespace UGF.Module.Serialize.Runtime
         public string DefaultText { get { return m_defaultText; } set { m_defaultText = value; } }
         public List<AssetReference<SerializerAsset>> Serializers { get { return m_serializers; } }
 
-        protected override SerializeModuleDescription OnGetDescription(IApplication application)
+        protected override IApplicationModuleDescription OnBuildDescription()
         {
-            var description = new SerializeModuleDescription
+            var description = new SerializeModuleDescription(typeof(ISerializeModule))
             {
                 DefaultBytesSerializeId = m_defaultBytes,
                 DefaultTextSerializerId = m_defaultText
@@ -42,9 +42,9 @@ namespace UGF.Module.Serialize.Runtime
             return description;
         }
 
-        protected override ISerializeModule OnBuild(IApplication application, SerializeModuleDescription description)
+        protected override ISerializeModule OnBuild(SerializeModuleDescription description, IApplication application)
         {
-            return new SerializeModule(application, description);
+            return new SerializeModule(description, application);
         }
     }
 }

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModuleDescription.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModuleDescription.cs
@@ -1,14 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using UGF.Application.Runtime;
 using UGF.Serialize.Runtime;
 
 namespace UGF.Module.Serialize.Runtime
 {
-    public class SerializeModuleDescription : ISerializeModuleDescription
+    public class SerializeModuleDescription : ApplicationModuleDescription, ISerializeModuleDescription
     {
         public string DefaultBytesSerializeId { get; set; }
         public string DefaultTextSerializerId { get; set; }
         public Dictionary<string, ISerializerBuilder> Serializers { get; } = new Dictionary<string, ISerializerBuilder>();
 
         IReadOnlyDictionary<string, ISerializerBuilder> ISerializeModuleDescription.Serializers { get { return Serializers; } }
+
+        public SerializeModuleDescription(Type registerType) : base(registerType)
+        {
+        }
     }
 }

--- a/Packages/UGF.Module.Serialize/Runtime/UGF.Module.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Module.Serialize/Runtime/UGF.Module.Serialize.Runtime.asmdef
@@ -6,6 +6,8 @@
         "GUID:d067af32d09350a4bb33960432735e4d",
         "GUID:e76e47a0b9e0396439161248a194baa5",
         "GUID:088d00b6871540e44bce58af1a3f0f17",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:3ad3a680cb737c6428dc532d551e7bb7",
         "GUID:6ca210c6fc8b79d4292f3cdb1061c73e"
     ],
     "includePlatforms": [],

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "com.ugf.application": "5.1.0",
     "com.ugf.serialize": "1.2.0",
-    "com.ugf.logs": "3.0.0"
+    "com.ugf.logs": "4.0.0"
   }
 }

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "com.ugf.application": "5.1.0",
-    "com.ugf.serialize": "1.2.0",
-    "com.ugf.logs": "4.0.0"
+    "com.ugf.serialize": "2.0.0",
+    "com.ugf.logs": "4.1.0"
   }
 }

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -22,7 +22,7 @@
     "registry": "https://api.bintray.com/content/unity-game-framework/public"
   },
   "dependencies": {
-    "com.ugf.application": "5.1.0",
+    "com.ugf.application": "6.0.0",
     "com.ugf.serialize": "2.0.0",
     "com.ugf.logs": "4.1.0"
   }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.test-framework": "1.1.18"
+    "com.unity.ide.rider": "3.0.3",
+    "com.unity.test-framework": "1.1.19"
   },
   "scopedRegistries": [
     {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,9 @@
 {
   "dependencies": {
+    "com.ugf.application": "file:../../ugf-application/Packages/UGF.Application",
+    "com.ugf.builder": "file:../../ugf-builder/Packages/UGF.Builder",
+    "com.ugf.description": "file:../../ugf-description/Packages/UGF.Description",
+    "com.ugf.serialize": "file:../../ugf-serialize/Packages/UGF.Serialize",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.ugf.application": "file:../../ugf-application/Packages/UGF.Application",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,6 @@
 {
   "dependencies": {
     "com.ugf.application": "file:../../ugf-application/Packages/UGF.Application",
-    "com.ugf.builder": "file:../../ugf-builder/Packages/UGF.Builder",
-    "com.ugf.description": "file:../../ugf-description/Packages/UGF.Description",
-    "com.ugf.serialize": "file:../../ugf-serialize/Packages/UGF.Serialize",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.19"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -12,27 +12,27 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.customsettings": {
-      "version": "3.0.1",
-      "depth": 2,
+      "version": "3.1.0",
+      "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.ugf.editortools": "1.1.0"
+        "com.ugf.editortools": "1.6.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.defines": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.0.1",
-        "com.ugf.editortools": "1.3.1"
+        "com.ugf.customsettings": "3.1.0",
+        "com.ugf.editortools": "1.6.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
-      "version": "1.5.1",
-      "depth": 2,
+      "version": "1.6.0",
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
@@ -45,11 +45,11 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "1.0.1"
+        "com.ugf.defines": "2.0.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -60,7 +60,7 @@
       "dependencies": {
         "com.ugf.application": "5.1.0",
         "com.ugf.serialize": "1.2.0",
-        "com.ugf.logs": "3.0.0"
+        "com.ugf.logs": "4.0.0"
       }
     },
     "com.ugf.serialize": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,22 +1,27 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "5.1.0",
+      "version": "file:../../ugf-application/Packages/UGF.Application",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {
+        "com.ugf.initialize": "2.6.0",
+        "com.ugf.customsettings": "3.4.0",
+        "com.ugf.editortools": "1.7.0"
+      }
+    },
+    "com.ugf.builder": {
+      "version": "file:../../ugf-builder/Packages/UGF.Builder",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {}
+    },
+    "com.ugf.customsettings": {
+      "version": "3.4.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.initialize": "2.4.0",
-        "com.ugf.customsettings": "3.0.1",
-        "com.ugf.editortools": "1.5.1"
-      },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
-    },
-    "com.ugf.customsettings": {
-      "version": "3.1.0",
-      "depth": 3,
-      "source": "registry",
-      "dependencies": {
-        "com.ugf.editortools": "1.6.0"
+        "com.ugf.editortools": "1.7.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -30,16 +35,22 @@
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
+    "com.ugf.description": {
+      "version": "file:../../ugf-description/Packages/UGF.Description",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {}
+    },
     "com.ugf.editortools": {
-      "version": "1.6.0",
-      "depth": 3,
+      "version": "1.7.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
-      "version": "2.4.0",
-      "depth": 2,
+      "version": "2.6.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
@@ -64,13 +75,12 @@
       }
     },
     "com.ugf.serialize": {
-      "version": "1.2.0",
-      "depth": 1,
-      "source": "registry",
+      "version": "file:../../ugf-serialize/Packages/UGF.Serialize",
+      "depth": 0,
+      "source": "local",
       "dependencies": {
         "com.ugf.editortools": "1.3.1"
-      },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      }
     },
     "com.unity.ext.nunit": {
       "version": "1.0.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -73,14 +73,14 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "2.0.7",
+      "version": "3.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -89,11 +89,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.18",
+      "version": "1.1.19",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.5",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -6,15 +6,17 @@
       "source": "local",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
+        "com.ugf.description": "2.0.0",
         "com.ugf.customsettings": "3.4.0",
         "com.ugf.editortools": "1.7.0"
       }
     },
     "com.ugf.builder": {
-      "version": "file:../../ugf-builder/Packages/UGF.Builder",
-      "depth": 0,
-      "source": "local",
-      "dependencies": {}
+      "version": "2.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
@@ -26,20 +28,22 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.defines": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.1.0",
-        "com.ugf.editortools": "1.6.0"
+        "com.ugf.customsettings": "3.4.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.description": {
-      "version": "file:../../ugf-description/Packages/UGF.Description",
-      "depth": 0,
-      "source": "local",
-      "dependencies": {}
+      "version": "2.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.ugf.builder": "2.0.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
       "version": "1.7.0",
@@ -56,11 +60,11 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.logs": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.0.0"
+        "com.ugf.defines": "2.1.0"
       },
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
@@ -70,17 +74,19 @@
       "source": "embedded",
       "dependencies": {
         "com.ugf.application": "5.1.0",
-        "com.ugf.serialize": "1.2.0",
-        "com.ugf.logs": "4.0.0"
+        "com.ugf.serialize": "2.0.0",
+        "com.ugf.logs": "4.1.0"
       }
     },
     "com.ugf.serialize": {
-      "version": "file:../../ugf-serialize/Packages/UGF.Serialize",
-      "depth": 0,
-      "source": "local",
+      "version": "2.0.0",
+      "depth": 1,
+      "source": "registry",
       "dependencies": {
-        "com.ugf.editortools": "1.3.1"
-      }
+        "com.ugf.builder": "2.0.0",
+        "com.ugf.editortools": "1.7.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
       "version": "1.0.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "file:../../ugf-application/Packages/UGF.Application",
-      "depth": 0,
-      "source": "local",
+      "version": "6.0.0",
+      "depth": 1,
+      "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.editortools": "1.7.0"
-      }
+        "com.ugf.customsettings": "3.4.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.builder": {
       "version": "2.0.0",
@@ -20,7 +20,7 @@
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
@@ -38,7 +38,7 @@
     },
     "com.ugf.description": {
       "version": "2.0.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.builder": "2.0.0"
@@ -47,14 +47,14 @@
     },
     "com.ugf.editortools": {
       "version": "1.7.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
@@ -73,7 +73,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "5.1.0",
+        "com.ugf.application": "6.0.0",
         "com.ugf.serialize": "2.0.0",
         "com.ugf.logs": "4.1.0"
       }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b6
-m_EditorVersionWithRevision: 2020.2.0b6 (24a0f8b56f72)
+m_EditorVersion: 2020.2.0b12
+m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)


### PR DESCRIPTION
- Update to use `UGF.Builder` and `UGF.Description` packages from the latest version of `UGF.Application` package.
- Change dependencies: `com.ugf.application` to `6.0.0`, `com.ugf.serialize` to `2.0.0`, `com.ugf.logs` to `4.1.0`.
- Change name of the root of create assets menu, from `UGF` to `Unity Game Framework`.