### PR TITLE
Rework provider and update application

### DIFF
--- a/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
@@ -1,4 +1,5 @@
 using UGF.Application.Runtime;
+using UGF.RuntimeTools.Runtime.Providers;
 using UGF.Serialize.Runtime;
 
 namespace UGF.Module.Serialize.Runtime
@@ -6,11 +7,9 @@ namespace UGF.Module.Serialize.Runtime
     public interface ISerializeModule : IApplicationModule
     {
         new ISerializeModuleDescription Description { get; }
-        ISerializerProvider Provider { get; }
+        IProvider<string, ISerializer> Provider { get; }
 
         ISerializer<byte[]> GetDefaultBytesSerializer();
         ISerializer<string> GetDefaultTextSerializer();
-        ISerializerBuilder GetSerializerBuilder(string id);
-        bool TryGetSerializerBuilder(string id, out ISerializerBuilder builder);
     }
 }

--- a/Packages/UGF.Module.Serialize/Runtime/UGF.Module.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Module.Serialize/Runtime/UGF.Module.Serialize.Runtime.asmdef
@@ -8,7 +8,8 @@
         "GUID:088d00b6871540e44bce58af1a3f0f17",
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
         "GUID:3ad3a680cb737c6428dc532d551e7bb7",
-        "GUID:6ca210c6fc8b79d4292f3cdb1061c73e"
+        "GUID:6ca210c6fc8b79d4292f3cdb1061c73e",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "7.1.0",
+    "com.ugf.application": "8.0.0-preview.4",
     "com.ugf.serialize": "4.0.0"
   }
 }

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.module.serialize",
   "displayName": "UGF.Module.Serialize",
   "version": "3.1.0",
-  "unity": "2020.2",
+  "unity": "2021.1",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Module to manage multiple serializers in an application.",
   "author": {
@@ -13,13 +13,10 @@
     "type": "git",
     "url": "git://github.com/unity-game-framework/ugf-module-serialize.git"
   },
-  "changelogUrl": "https://github.com/unity-game-framework/ugf-module-serialize/blob/master/changelog.md",
-  "licensesUrl": "https://github.com/unity-game-framework/ugf-module-serialize/blob/master/license",
+  "changelogUrl": "https://github.com/unity-game-framework/ugf-module-serialize/blob/main/changelog.md",
+  "licensesUrl": "https://github.com/unity-game-framework/ugf-module-serialize/blob/main/license",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@unity-game-framework"
-  },
-  "bintray": {
-    "registry": "https://api.bintray.com/content/unity-game-framework/public"
+    "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
     "com.ugf.application": "7.1.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.20"
+    "com.unity.ide.rider": "3.0.5",
+    "com.unity.test-framework": "1.1.22"
   },
   "scopedRegistries": [
     {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
   "scopedRegistries": [
     {
       "name": "Unity Game Framework",
-      "url": "https://api.bintray.com/npm/unity-game-framework/public",
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default",
       "scopes": [
         "com.ugf"
       ]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,14 +10,14 @@
         "com.ugf.customsettings": "3.4.0",
         "com.ugf.logs": "5.1.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.builder": {
       "version": "2.0.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
@@ -26,7 +26,7 @@
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
       "version": "2.1.0",
@@ -35,7 +35,7 @@
       "dependencies": {
         "com.ugf.customsettings": "3.4.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.description": {
       "version": "2.0.0",
@@ -44,21 +44,21 @@
       "dependencies": {
         "com.ugf.builder": "2.0.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
       "version": "1.8.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
       "version": "5.1.0",
@@ -67,7 +67,7 @@
       "dependencies": {
         "com.ugf.defines": "2.1.0"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.module.serialize": {
       "version": "file:UGF.Module.Serialize",
@@ -86,7 +86,7 @@
         "com.ugf.builder": "2.0.0",
         "com.ugf.editortools": "1.8.1"
       },
-      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.unity.ext.nunit": {
       "version": "1.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -96,16 +96,14 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.3",
+      "version": "3.0.5",
       "depth": 0,
       "source": "registry",
-      "dependencies": {
-        "com.unity.test-framework": "1.1.1"
-      },
+      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.20",
+      "version": "1.1.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "7.1.0",
+      "version": "8.0.0-preview.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.logs": "5.1.0"
+        "com.ugf.runtimetools": "2.0.0",
+        "com.ugf.logs": "5.1.3"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -21,7 +21,7 @@
     },
     "com.ugf.customsettings": {
       "version": "3.4.0",
-      "depth": 2,
+      "depth": 4,
       "source": "registry",
       "dependencies": {
         "com.ugf.editortools": "1.7.0"
@@ -29,11 +29,12 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.0",
+      "version": "2.1.2",
       "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.4.0"
+        "com.ugf.customsettings": "3.4.0",
+        "com.ugf.editortools": "1.10.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -47,8 +48,8 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.8.1",
-      "depth": 2,
+      "version": "1.10.0",
+      "depth": 4,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -61,11 +62,11 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
-      "version": "5.1.0",
+      "version": "5.1.3",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.1.0"
+        "com.ugf.defines": "2.1.2"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -74,9 +75,16 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "7.1.0",
+        "com.ugf.application": "8.0.0-preview.4",
         "com.ugf.serialize": "4.0.0"
       }
+    },
+    "com.ugf.runtimetools": {
+      "version": "2.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.serialize": {
       "version": "4.0.0",

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -12,10 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EnablePreviewPackages: 1
+  m_EnablePreReleasePackages: 0
   m_EnablePackageDependencies: 1
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
+  m_SeeAllPackageVersions: 0
   oneTimeWarningShown: 1
   m_Registries:
   - m_Id: main
@@ -26,26 +27,27 @@ MonoBehaviour:
     m_Capabilities: 7
   - m_Id: scoped:Unity Game Framework
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_IsDefault: 0
     m_Capabilities: 0
-  m_UserSelectedRegistryName: 
+  m_UserSelectedRegistryName: Unity Game Framework
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
       m_Id: scoped:Unity Game Framework
       m_Name: Unity Game Framework
-      m_Url: https://api.bintray.com/npm/unity-game-framework/public
+      m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
       m_Scopes:
       - com.ugf
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_SelectedScopeIndex: 0
+  m_LoadAssets: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.1f1
-m_EditorVersionWithRevision: 2020.2.1f1 (270dd8c3da1c)
+m_EditorVersion: 2021.1.0b8
+m_EditorVersionWithRevision: 2021.1.0b8 (4a0a5fc962a9)


### PR DESCRIPTION
- Update project to _Unity_ of `2021.1` version.
- Update package publish registry.
- Change dependencies: `com.ugf.application` to `8.0.0-preview.4`.
- Replace `ISerializerProvider ` provider by `IProvider<string, ISerializer>` interface from _UGF.RuntimeTools_ package.
- Remove `GetSerializerBuilder` and `TryGetSerializerBuilder` methods from `SerializeModule ` class and `ISerializeModule` interface.