### PR TITLE
Update for latest serialize package

### DIFF
--- a/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/ISerializeModule.cs
@@ -1,4 +1,5 @@
 using UGF.Application.Runtime;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.RuntimeTools.Runtime.Providers;
 using UGF.Serialize.Runtime;
 
@@ -8,6 +9,7 @@ namespace UGF.Module.Serialize.Runtime
     {
         new ISerializeModuleDescription Description { get; }
         IProvider<string, ISerializer> Provider { get; }
+        IContext Context { get; }
 
         ISerializer<byte[]> GetDefaultBytesSerializer();
         ISerializer<string> GetDefaultTextSerializer();

--- a/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
+++ b/Packages/UGF.Module.Serialize/Runtime/SerializeModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UGF.Application.Runtime;
 using UGF.Logs.Runtime;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.RuntimeTools.Runtime.Providers;
 using UGF.Serialize.Runtime;
 
@@ -10,16 +11,18 @@ namespace UGF.Module.Serialize.Runtime
     public class SerializeModule : ApplicationModule<SerializeModuleDescription>, ISerializeModule
     {
         public IProvider<string, ISerializer> Provider { get; }
+        public IContext Context { get; }
 
         ISerializeModuleDescription ISerializeModule.Description { get { return Description; } }
 
-        public SerializeModule(SerializeModuleDescription description, IApplication application) : this(description, application, new Provider<string, ISerializer>())
+        public SerializeModule(SerializeModuleDescription description, IApplication application) : this(description, application, new Provider<string, ISerializer>(), new Context { application })
         {
         }
 
-        public SerializeModule(SerializeModuleDescription description, IApplication application, IProvider<string, ISerializer> provider) : base(description, application)
+        public SerializeModule(SerializeModuleDescription description, IApplication application, IProvider<string, ISerializer> provider, IContext context) : base(description, application)
         {
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            Context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         protected override void OnInitialize()

--- a/Packages/UGF.Module.Serialize/package.json
+++ b/Packages/UGF.Module.Serialize/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.application": "8.0.0-preview.4",
-    "com.ugf.serialize": "4.0.0"
+    "com.ugf.application": "8.0.0-preview.8",
+    "com.ugf.serialize": "5.0.0-preview"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.5",
-    "com.unity.test-framework": "1.1.22"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -104,14 +104,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.5",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.22",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,40 +1,41 @@
 {
   "dependencies": {
     "com.ugf.application": {
-      "version": "8.0.0-preview.4",
+      "version": "8.0.0-preview.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
         "com.ugf.description": "2.0.0",
         "com.ugf.runtimetools": "2.0.0",
-        "com.ugf.logs": "5.1.3"
+        "com.ugf.logs": "5.1.4"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.builder": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.customsettings": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "depth": 4,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.editortools": "1.7.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.defines": {
-      "version": "2.1.2",
+      "version": "2.1.4",
       "depth": 3,
       "source": "registry",
       "dependencies": {
-        "com.ugf.customsettings": "3.4.0",
-        "com.ugf.editortools": "1.10.0"
+        "com.ugf.customsettings": "3.4.1",
+        "com.ugf.editortools": "1.11.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -48,8 +49,8 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.10.0",
-      "depth": 4,
+      "version": "1.11.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
@@ -62,11 +63,11 @@
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
-      "version": "5.1.3",
+      "version": "5.1.4",
       "depth": 2,
       "source": "registry",
       "dependencies": {
-        "com.ugf.defines": "2.1.2"
+        "com.ugf.defines": "2.1.4"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
@@ -75,24 +76,26 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.application": "8.0.0-preview.4",
-        "com.ugf.serialize": "4.0.0"
+        "com.ugf.application": "8.0.0-preview.8",
+        "com.ugf.serialize": "5.0.0-preview"
       }
     },
     "com.ugf.runtimetools": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.serialize": {
-      "version": "4.0.0",
+      "version": "5.0.0-preview",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.ugf.builder": "2.0.0",
-        "com.ugf.editortools": "1.8.1"
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.ugf.builder": "2.0.1",
+        "com.ugf.editortools": "1.11.1",
+        "com.ugf.runtimetools": "2.2.0"
       },
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.0b8
-m_EditorVersionWithRevision: 2021.1.0b8 (4a0a5fc962a9)
+m_EditorVersion: 2021.1.15f1
+m_EditorVersionWithRevision: 2021.1.15f1 (e767a7370072)


### PR DESCRIPTION
- Update dependencies: `com.ugf.application` to `8.0.0-preview.8` version and `com.ugf.serialize` to `5.0.0-preview` version.
- Add `ISerializeModule.Context` property to use with any serializer.